### PR TITLE
changes for multiple node elasticsearch cluster

### DIFF
--- a/manifests/elasticsearch-one-node.yaml
+++ b/manifests/elasticsearch-one-node.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitored-cluster
+spec:
+  selector:
+    component: 63-elasticsearch
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+    targetPort: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+    targetPort: 9300
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitored-cluster-headless
+spec: 
+  clusterIP: None  
+  selector:
+    component: 63-elasticsearch
+---
+
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: 63-elasticsearch
+  labels:
+    component: 63-elasticsearch
+spec:
+  replicas: 1
+  serviceName: monitored-cluster-headless  
+  template:
+    metadata: 
+      name: monitored-cluster
+      labels:
+        component: 63-elasticsearch  
+      annotations:
+        co.elastic.metrics.es-data/module: elasticsearch
+        co.elastic.metrics.es-data/hosts: "${data.host}:9200"    
+    spec:
+      initContainers:
+        - name: increase-the-vm-max-map-count
+          image: busybox
+          command:
+          - sysctl
+          - -w
+          - vm.max_map_count=262144
+          securityContext:
+            privileged: true
+        - name: increase-the-ulimit
+          image: busybox
+          command:
+          - sh
+          - -c
+          - ulimit -n 65536
+          securityContext:
+            privileged: true
+      containers:
+      - name: es-data
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.3.0
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 3
+          timeoutSeconds: 5
+          exec:
+            command: 
+              - sh
+              - -c
+              - "curl http://${HOSTNAME}:9200/_cluster/health"
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        env:
+          - name: node.name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: discovery.zen.minimum_master_nodes 
+            value: "2"
+          - name: MICKYEST
+            value: "6"
+          - name: network.host
+            value: "_site_"
+          - name: discovery.zen.ping.unicast.hosts
+            value: "monitored-cluster"
+          - name: cluster.name
+            value: "monitored-cluster"
+          - name: ES_JAVA_OPTS
+            value: -Xmx1g -Xms1g
+          - name: node.data
+            value: "true"
+          - name: node.ingest
+            value: "true"
+        

--- a/manifests/elasticsearch.yaml
+++ b/manifests/elasticsearch.yaml
@@ -1,85 +1,104 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Service
 metadata:
-  name: elasticsearch
-  labels:
-    app: elasticsearch
+  name: monitored-cluster
 spec:
-  replicas: 1
   selector:
-    matchLabels:
-      app: elasticsearch
-  template:
-    metadata:
-      labels:
-        app: elasticsearch
-      annotations:
-        co.elastic.metrics.elasticsearch/module: elasticsearch
-        co.elastic.metrics.elasticsearch/hosts: "${data.host}:9200"
-    spec:
-      terminationGracePeriodSeconds: 300
-      initContainers:
-      - name: fix-the-volume-permission
-        image: busybox
-        command:
-        - sh
-        - -c
-        - chown -R 1000:1000 /usr/share/elasticsearch/data
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: data
-          mountPath: /usr/share/elasticsearch/data
-      - name: increase-the-vm-max-map-count
-        image: busybox
-        command:
-        - sysctl
-        - -w
-        - vm.max_map_count=262144
-        securityContext:
-          privileged: true
-      - name: increase-the-ulimit
-        image: busybox
-        command:
-        - sh
-        - -c
-        - ulimit -n 65536
-        securityContext:
-          privileged: true
-      containers:
-      - name: elasticsearch
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.3.0
-        ports:
-        - containerPort: 9200
-          name: http
-        env:
-          - name: cluster.name
-            value: elasticsearch-cluster
-          - name: node.name
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: ES_JAVA_OPTS
-            value: -Xms2g -Xmx2g
-        volumeMounts:
-        - name: data
-          mountPath: /usr/share/elasticsearch/data
-      volumes:
-        - name: data
-          hostPath:
-            path: /var/lib/elasticsearch-data
+    component: 63-elasticsearch
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+    targetPort: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+    targetPort: 9300
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: elasticsearch
-  labels:
-    service: elasticsearch
-spec:
-  type: NodePort
+  name: monitored-cluster-headless
+spec: 
+  clusterIP: None  
   selector:
-    app: elasticsearch
-  ports:
-  - port: 9200
-    nodePort: 9200
-    name: http
+    component: 63-elasticsearch
+---
+
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: 63-elasticsearch
+  labels:
+    component: 63-elasticsearch
+spec:
+  replicas: 3
+  serviceName: monitored-cluster-headless  
+  template:
+    metadata: 
+      name: monitored-cluster
+      labels:
+        component: 63-elasticsearch  
+      annotations:
+        co.elastic.metrics.es-data/module: elasticsearch
+        co.elastic.metrics.es-data/hosts: "${data.host}:9200"    
+    spec:
+      initContainers:
+        - name: increase-the-vm-max-map-count
+          image: busybox
+          command:
+          - sysctl
+          - -w
+          - vm.max_map_count=262144
+          securityContext:
+            privileged: true
+        - name: increase-the-ulimit
+          image: busybox
+          command:
+          - sh
+          - -c
+          - ulimit -n 65536
+          securityContext:
+            privileged: true
+      containers:
+      - name: es-data
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.3.0
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 3
+          timeoutSeconds: 5
+          exec:
+            command: 
+              - sh
+              - -c
+              - "curl http://${HOSTNAME}:9200/_cluster/health"
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        env:
+          - name: node.name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: discovery.zen.minimum_master_nodes 
+            value: "2"
+          - name: MICKYEST
+            value: "6"
+          - name: network.host
+            value: "_site_"
+          - name: discovery.zen.ping.unicast.hosts
+            value: "monitored-cluster"
+          - name: cluster.name
+            value: "monitored-cluster"
+          - name: ES_JAVA_OPTS
+            value: -Xmx1g -Xms1g
+          - name: node.data
+            value: "true"
+          - name: node.ingest
+            value: "true"
+        

--- a/manifests/filebeat.yaml
+++ b/manifests/filebeat.yaml
@@ -16,7 +16,7 @@ data:
       - add_cloud_metadata:
 
     output.elasticsearch:
-      hosts: ['elasticsearch:9200']
+      hosts: ['monitored-cluster:9200']
 
     setup.kibana:
       host: kibana

--- a/manifests/kibana.yaml
+++ b/manifests/kibana.yaml
@@ -1,18 +1,19 @@
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kibana
   labels:
-    app: kibana
+    run: kibana
+    name: kibana
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kibana
+      run: kibana
   template:
     metadata:
       labels:
-        app: kibana
+        run: kibana
       annotations:
         co.elastic.metrics.kibana/module: kibana
         co.elastic.metrics.kibana/hosts: "${data.host}:5601"
@@ -23,7 +24,7 @@ spec:
           command:
             - sh
             - -c
-            - until wget -q elasticsearch:9200; do echo Waiting for elasticsearch; sleep 1; done
+            - until nslookup monitored-cluster; do echo waiting for monitored-cluster; sleep 2; done;
       containers:
       - name: kibana
         image: docker.elastic.co/kibana/kibana:6.3.0
@@ -34,9 +35,10 @@ spec:
             cpu: 100m
         env:
           - name: ELASTICSEARCH_URL
-            value: http://elasticsearch:9200
+            value: http://monitored-cluster:9200
         ports:
         - containerPort: 5601
+          hostPort: 5601
           name: ui
 ---
 apiVersion: v1
@@ -46,10 +48,10 @@ metadata:
   labels:
     service: kibana
 spec:
-  type: NodePort
-  selector:
-    app: kibana
   ports:
   - port: 5601
-    nodePort: 5601
-    name: ui
+    protocol: TCP
+    targetPort: 5601
+  selector:
+    run: kibana
+  type: NodePort

--- a/manifests/metricbeat.yaml
+++ b/manifests/metricbeat.yaml
@@ -7,6 +7,11 @@ metadata:
     app: metricbeat
 data:
   metricbeat.yml: |-
+    metricbeat.autodiscover:      
+      providers:
+        - type: kubernetes
+          host: "${HOSTNAME}"
+          hints.enabled: true
     metricbeat.modules:
     - module: system
       period: 10s
@@ -42,8 +47,9 @@ data:
         - container
         - volume
         - event
-      period: 10s
+      period: 10s      
       hosts: ["localhost:10255"]
+      host: "${HOSTNAME}"
 
     - module: kubernetes
       metricsets:
@@ -54,20 +60,18 @@ data:
         - state_container
       period: 10s
       hosts: ["kube-state-metrics:8080"]
+      host: "${HOSTNAME}"
 
-    processors:
-      - add_cloud_metadata:
-
-    metricbeat.autodiscover:
-      providers:
-        - type: kubernetes
-          host: ${HOSTNAME}
-          hints.enabled: true
+   
+    - module: kibana
+      period: 10s
+      hosts: ["kibana:5601"]   
+       
 
     setup.kibana.host: "kibana:5601"
 
     output.elasticsearch:
-      hosts: ['elasticsearch:9200']
+      hosts: ['monitored-cluster:9200']
 ---
 # Deploy a Metricbeat instance per node for node metrics retrieval
 apiVersion: extensions/v1beta1
@@ -94,7 +98,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.3.0
+        image: ruflin/mb-snapshot
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -162,15 +166,22 @@ metadata:
   labels:
     k8s-app: metricbeat
 rules:
-- apiGroups: [""] # "" indicates the core API group
+- apiGroups: [""]
   resources:
+  - nodes
   - namespaces
   - events
   - pods
-  verbs:
-  - get
-  - watch
-  - list
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  - replicasets
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Changes for making the monitored cluster composed of 3 ES nodes
The main changes are in the elasticsearch.yaml where a StatefulSet object was introduced to work with a headless service and a pod of 3 replicas of elasticsearch
The other service which is a NodPort allows access to Elasticsearch from port 9200

Changes made to metricbeat.yaml allows for autodiscovery of elasticsearch containers using annotations
